### PR TITLE
Fix DoRA extraction crash on 1-D weights (x_pad_token, norm weights)

### DIFF
--- a/nodes/dora_extract_wd.py
+++ b/nodes/dora_extract_wd.py
@@ -551,6 +551,14 @@ def extract_dora_from_files(
                     dora_scale = None
                     del tensor_b
                 else:
+                    # 1-D weights (e.g. x_pad_token, norm .weight) have no
+                    # weight-decomposition direction and are skipped below
+                    # anyway; bail out before the norm, which would index
+                    # dim=1 and raise on a 1-D tensor.
+                    if tensor_a.ndim < 2:
+                        del tensor_a, tensor_b
+                        return "skipped", None
+
                     # Weight Decomposition calculation
                     is_conv_dim = tensor_a.ndim == 4
                     


### PR DESCRIPTION
Fixes #15.

Extracting a DoRA from models that contain 1-D weights (e.g. z-image's `x_pad_token`, or LayerNorm/RMSNorm `.weight`) crashes with:

```
Dimension out of range (expected to be in range of [-1, 0], but got 1)
  nodes/dora_extract_wd.py -> torch.linalg.norm(tensor_a, dim=1, keepdim=True)
```

In the matched-shape branch, `is_conv_dim = tensor_a.ndim == 4` sends every non-4-D tensor to `torch.linalg.norm(..., dim=1)`. A 1-D tensor has no `dim=1`, so it raises and aborts the whole extraction. The function already discards 1-D tensors a few lines later (the `weight_diff.ndim < 2` skip), so this just bails out before the norm instead.

Verified with a CPU repro of the exact branch:

```
1-D input (x_pad_token / norm.weight):  before -> IndexError (dim 1) ;  after -> skipped
2-D input:                              still processed
4-D conv input:                         still processed
```